### PR TITLE
Update Dockerfile to remove node version incompatibility error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-slim
+FROM node:current
 RUN npm install -g firebase-tools
 COPY entrypoint.sh /usr/local/bin
 ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
Node version updated to be compatible with all the latest `firebase-tools` packages to prevent the incompatible error