### PR TITLE
Add functions only deploy flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-slim
+FROM node:18-slim
 RUN npm install -g firebase-tools
 COPY entrypoint.sh /usr/local/bin
 ENTRYPOINT ["entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 build:
-	docker build . -t jsryudev/deploy-firebase-functions
+	docker build . -t dayzero-eng/deploy-firebase-functions

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A GitHub Action to deploy to Firebase for Node18.
 - Make sure that you checkout the repository using the [actions/checkout](https://github.com/actions/checkout) action
 - Make sure that you have the `firebase.json` file in the repository
 - To obtain the Firebase token, run `firebase login:ci` on your local computer and [store the token](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) as the `FIREBASE_TOKEN` secret
+- To obtain service account credentials, get the service account JSON file from Firebase console and set its path to `GOOGLE_APPLICATION_CREDENTIALS`
+- Either `FIREBASE_TOKEN` or `GOOGLE_APPLICATION_CREDENTIALS` are required to deploy the project. No need to set both at the same time.
 - Specify the Firebase project name in the `FIREBASE_PROJECT` env var
 
 ## Workflow examples

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Deploy to Firebase Functions for Node18
+# Deploy to Firebase for Node18
 
-A GitHub Action to deploy to Firebase Cloud Functions for Node18.
+A GitHub Action to deploy to Firebase for Node18.
 
 - Make sure that you checkout the repository using the [actions/checkout](https://github.com/actions/checkout) action
 - Make sure that you have the `firebase.json` file in the repository
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: dayzero-eng/deploy-firebase-functions@v0.0.1
+    - uses: dayzero-eng/deploy-firebase-functions@v0.0.5
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         FIREBASE_PROJECT: firebase-project-id
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: dayzero-eng/deploy-firebase-functions@v0.0.2
+    - uses: dayzero-eng/deploy-firebase-functions@v0.0.5
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         FIREBASE_PROJECT: firebase-project-id

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Deploy to Firebase Functions for Node14
+# Deploy to Firebase Functions for Node18
 
-A GitHub Action to deploy to Firebase Cloud Functions for Node14.
+A GitHub Action to deploy to Firebase Cloud Functions for Node18.
 
 - Make sure that you checkout the repository using the [actions/checkout](https://github.com/actions/checkout) action
 - Make sure that you have the `firebase.json` file in the repository
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: jsryudev/deploy-firebase-functions@v0.0.2
+    - uses: dayzero-eng/deploy-firebase-functions@v0.0.1
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         FIREBASE_PROJECT: firebase-project-id
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: jsryudev/deploy-firebase-functions@v0.0.2
+    - uses: dayzero-eng/deploy-firebase-functions@v0.0.2
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         FIREBASE_PROJECT: firebase-project-id

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A GitHub Action to deploy to Firebase for Node18.
 - To obtain the Firebase token, run `firebase login:ci` on your local computer and [store the token](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) as the `FIREBASE_TOKEN` secret
 - To obtain service account credentials, get the service account JSON file from Firebase console and set its path to `GOOGLE_APPLICATION_CREDENTIALS`
 - Either `FIREBASE_TOKEN` or `GOOGLE_APPLICATION_CREDENTIALS` are required to deploy the project. No need to set both at the same time.
-- Specify the Firebase project name in the `FIREBASE_PROJECT` env var
+- Specify the Firebase project name in the `FIREBASE_PROJECT` env var.
+- By default, the action will deploy all firebase components. If you just want to deploy the functions, set `FUNCTIONS_ONLY` env var to any value.
 
 ## Workflow examples
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'Deploy to Firebase Cloud Functions'
-author: 'jsryudev <jsryu.dev@gmail.com>'
-description: 'A GitHub Action to deploy to Firebase Cloud Functions'
+name: 'Deploy to Firebase'
+author: 'dayzero-eng'
+description: 'A GitHub Action to deploy to Firebase'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,3 +21,4 @@ firebase experiments:enable webframeworks
 firebase deploy \
     -m "${GITHUB_REF} (${GITHUB_SHA})" \
     --project ${FIREBASE_PROJECT} \
+    ${FUNCTIONS_ONLY:+--only functions}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+npm install
+
 cd functions; npm install
 
 if [ -z "${FIREBASE_TOKEN}" ]; then
@@ -11,6 +13,8 @@ if [ -z "${FIREBASE_PROJECT}" ]; then
     echo "FIREBASE_PROJECT is missing"
     exit 1
 fi
+
+cd ..
 
 firebase experiments:enable webframeworks
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,8 @@ npm install
 
 cd functions; npm install
 
-if [ -z "${FIREBASE_TOKEN}" ]; then
-    echo "FIREBASE_TOKEN is missing"
+if [[ -z "${FIREBASE_TOKEN}" && -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
+    echo "Access tokens are missing! Provide either FIREBASE_TOKEN or GOOGLE_APPLICATION_CREDENTIALS"
     exit 1
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,4 +15,3 @@ fi
 firebase deploy \
     -m "${GITHUB_REF} (${GITHUB_SHA})" \
     --project ${FIREBASE_PROJECT} \
-    --only functions

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,8 @@ if [ -z "${FIREBASE_PROJECT}" ]; then
     exit 1
 fi
 
+firebase experiments:enable webframeworks
+
 firebase deploy \
     -m "${GITHUB_REF} (${GITHUB_SHA})" \
     --project ${FIREBASE_PROJECT} \


### PR DESCRIPTION
This PR enables the action to deploy only the project's firebase functions if the environment variable `FUNCTIONS_ONLY` is set.