### PR TITLE
Update Dockerfile with node 16 compatible firebase tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM node:16-slim
-RUN npm install -g firebase-tools
+RUN npm install -g firebase-tools@12.9.1
 COPY entrypoint.sh /usr/local/bin
 ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
Latest firebase tools is not compatible with  node 16